### PR TITLE
Use GitHub Actions to build and publish page

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,19 @@
+name: "Jekyll build"
+
+on: pull_request
+
+jobs:
+  jekyll:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: helaili/jekyll-action@v2
+      with:
+        build_only: true
+        jekyll_build_options: -d _site
+    
+    - uses: actions/upload-artifact@v2
+      with:
+        name: page
+        path: _site

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: "Jekyll build and publish"
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  jekyll:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: helaili/jekyll-action@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+# https://pages.github.com/versions/
+
+gem 'jekyll', '~> 3.9'
+gem 'kramdown-parser-gfm', '~> 1.1'
+
+group :jekyll_plugins do
+  gem 'jekyll-seo-tag', '~> 2.7'
+  gem 'jekyll-sitemap', '~> 1.4'
+end


### PR DESCRIPTION
This will allow to add custom build steps in the future, for example automatically building the playground from the corresponding repo, or pulling in the spec from the specification repo.

After merging this PR, the page is stored in the `gh-pages` branch on every new commit to `master`. The settings of this repo have to be changed then to publish the website from the `gh-pages` branch instead of `master`.