### PR TITLE
Update prefixes.yaml

### DIFF
--- a/_data/prefixes.yaml
+++ b/_data/prefixes.yaml
@@ -1,7 +1,7 @@
 covjson: https://covjson.org/def/core#
 covjsondt: https://covjson.org/def/domainTypes#
 xsd: http://www.w3.org/2001/XMLSchema#
-ssn: http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#
+ssn: http://www.w3.org/ns/sosa#
 skos: http://www.w3.org/2004/02/skos/core#
 dct: http://purl.org/dc/terms/
 hydra: http://www.w3.org/ns/hydra/core#
@@ -10,3 +10,4 @@ ignf: http://data.ign.fr/def/ignf#
 inspiregloss: http://inspire.ec.europa.eu/glossary/
 rel: http://www.iana.org/assignments/relation/
 metocean: https://api.meteogate.eu/profiles/metocean/covjson
+sosa: http://www.w3.org/ns/sosa#

--- a/_data/prefixes.yaml
+++ b/_data/prefixes.yaml
@@ -9,3 +9,4 @@ qudt: http://qudt.org/schema/qudt#
 ignf: http://data.ign.fr/def/ignf#
 inspiregloss: http://inspire.ec.europa.eu/glossary/
 rel: http://www.iana.org/assignments/relation/
+metocean: https://api.meteogate.eu/profiles/metocean/covjson

--- a/_data/prefixes.yaml
+++ b/_data/prefixes.yaml
@@ -1,7 +1,7 @@
 covjson: https://covjson.org/def/core#
 covjsondt: https://covjson.org/def/domainTypes#
 xsd: http://www.w3.org/2001/XMLSchema#
-ssn: http://www.w3.org/ns/sosa#
+ssn: http://www.w3.org/2005/Incubator/ssn/ssnx/ssn#
 skos: http://www.w3.org/2004/02/skos/core#
 dct: http://purl.org/dc/terms/
 hydra: http://www.w3.org/ns/hydra/core#

--- a/_data/prefixes.yaml
+++ b/_data/prefixes.yaml
@@ -9,5 +9,5 @@ qudt: http://qudt.org/schema/qudt#
 ignf: http://data.ign.fr/def/ignf#
 inspiregloss: http://inspire.ec.europa.eu/glossary/
 rel: http://www.iana.org/assignments/relation/
-metocean: https://api.meteogate.eu/profiles/metocean/covjson
+meteogate: https://api.meteogate.eu/profiles/metocean/covjson
 sosa: http://www.w3.org/ns/sosa#

--- a/context.jsonld
+++ b/context.jsonld
@@ -51,7 +51,7 @@
     
     "Parameter": "covjson:Parameter",
     "parameters": { "@id": "covjson:parameter", "@type": "@id", "@container": "@index" },
-    "observedProperty": "ssn:observedProperty",
+    "observedProperty": "sosa:observedProperty",
     "categoryEncoding": "covjson:categoryEncoding",
     "ParameterGroup": "covjson:ParameterGroup",
     "members": { "@id": "covjson:member", "@type": "@vocab", "@container": "@set" },

--- a/context.jsonld
+++ b/context.jsonld
@@ -51,7 +51,12 @@
     
     "Parameter": "covjson:Parameter",
     "parameters": { "@id": "covjson:parameter", "@type": "@id", "@container": "@index" },
+    
     "observedProperty": "sosa:observedProperty",
+    "usedProcedure": "sosa:usedProcedure"
+    "madeBySensor": "sosa:madeBySensor"
+    "hasFeatureOfInterest": "sosa:hasFeatureOfInterest"
+  
     "categoryEncoding": "covjson:categoryEncoding",
     "ParameterGroup": "covjson:ParameterGroup",
     "members": { "@id": "covjson:member", "@type": "@vocab", "@container": "@set" },


### PR DESCRIPTION
Add `metocean:` prefix for European Met services extra metadata, and add `sosa:` prefix in preference to `ssn:`.